### PR TITLE
Fix several issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cargo-bdeps"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "clap 2.33.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "json 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,8 +13,8 @@ name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "hermit-abi 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hermit-abi 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -24,16 +24,16 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "cargo-build-deps"
+name = "cargo-bdeps"
 version = "0.1.5"
 dependencies = [
- "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.33.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "clap"
-version = "2.33.0"
+version = "2.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -42,25 +42,25 @@ dependencies = [
  "strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vec_map 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.6"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.66"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.104"
+version = "1.0.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -81,7 +81,7 @@ name = "toml"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.112 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -91,7 +91,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "vec_map"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -117,15 +117,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
-"checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
-"checksum hermit-abi 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "eff2656d88f158ce120947499e971d743c05dbcbed62e5bd2f38f1698bbc3772"
-"checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
-"checksum serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)" = "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449"
+"checksum clap 2.33.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bdfa80d47f954d53a35a64987ca1422f495b8d6483c0fe9f7117b36c2a792129"
+"checksum hermit-abi 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "b9586eedd4ce6b3c498bc3b4dd92fc9f11166aa908a914071953768066c67909"
+"checksum libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)" = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
+"checksum serde 1.0.112 (registry+https://github.com/rust-lang/crates.io-index)" = "736aac72d1eafe8e5962d1d1c3d99b0df526015ba40915cb3c49d042e92ec243"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"
 "checksum unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
-"checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
+"checksum vec_map 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 "checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cargo-bdeps"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "clap 2.33.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cargo-build-deps"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -13,9 +13,9 @@ name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "hermit-abi 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hermit-abi 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -28,6 +28,8 @@ name = "cargo-bdeps"
 version = "0.1.6"
 dependencies = [
  "clap 2.33.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "json 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -41,17 +43,22 @@ dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "vec_map 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "json"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
@@ -59,8 +66,21 @@ version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "semver"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "serde"
-version = "1.0.112"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -73,7 +93,7 @@ name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -81,12 +101,12 @@ name = "toml"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.112 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "unicode-width"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -96,7 +116,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -118,14 +138,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum clap 2.33.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bdfa80d47f954d53a35a64987ca1422f495b8d6483c0fe9f7117b36c2a792129"
-"checksum hermit-abi 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "b9586eedd4ce6b3c498bc3b4dd92fc9f11166aa908a914071953768066c67909"
+"checksum hermit-abi 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9"
+"checksum json 0.12.4 (registry+https://github.com/rust-lang/crates.io-index)" = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
 "checksum libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)" = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
-"checksum serde 1.0.112 (registry+https://github.com/rust-lang/crates.io-index)" = "736aac72d1eafe8e5962d1d1c3d99b0df526015ba40915cb3c49d042e92ec243"
+"checksum semver 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "394cec28fa623e00903caf7ba4fa6fb9a0e260280bb8cdbbba029611108a0190"
+"checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+"checksum serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)" = "5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"
-"checksum unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
+"checksum unicode-width 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 "checksum vec_map 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-"checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
+"checksum winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-bdeps"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["Nick Cardin <nick@cardin.email>", "errmac-v"]
 categories = [
     "development-tools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-build-deps"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Nick Cardin <nick@cardin.email>"]
 categories = [
     "development-tools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,5 @@ readme = "README.md"
 [dependencies]
 toml = "0.5"
 clap = "2.33"
+semver = "0.10.0"
+json = "0.12.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-bdeps"
 version = "0.1.5"
-authors = ["Nick Cardin <nick@cardin.email>"]
+authors = ["Nick Cardin <nick@cardin.email>", "errmac-v"]
 categories = [
     "development-tools",
     "development-tools::cargo-plugins",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "cargo-build-deps"
+name = "cargo-bdeps"
 version = "0.1.5"
 authors = ["Nick Cardin <nick@cardin.email>"]
 categories = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-bdeps"
-version = "0.1.6"
+version = "0.1.7"
 authors = ["Nick Cardin <nick@cardin.email>", "errmac-v"]
 categories = [
     "development-tools",

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,13 +30,13 @@ fn main() {
     let cargo_toml = get_toml("Cargo.toml");
     let dependencies = parse_dependencies(&cargo_toml);
 
-    println!("Start building packages");
+    println!("    Start building packages");
 
     for dependency in dependencies {
         build_package(&dependency, is_release, &target);
     }
 
-    println!("Finished");
+    println!("    Finished");
 }
 
 fn get_toml(file_path: &str) -> Toml {
@@ -73,7 +73,9 @@ fn format_package(name: &String, value: &Toml) -> String {
 }
 
 fn build_package(pkg_name: &str, is_release: bool, target: &str) {
-    println!("Building package: {:?}", pkg_name);
+    let pkg_name = pkg_name.split(':').next().expect("Couldn't get package name");
+
+    println!("    Building package: {:?}", pkg_name);
 
     let mut command = Command::new("cargo");
     let command_with_args = command.arg("build").arg("-p").arg(pkg_name);

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ fn main() {
         .arg(Arg::with_name("build-deps"))
         .arg(Arg::with_name("release").long("release"))
         .arg(Arg::with_name("target").long("target"))
+        .arg(Arg::with_name("skip-update").long("skip-update"))
         .get_matches();
 
     let is_release = matched_args.is_present("release");
@@ -22,7 +23,9 @@ fn main() {
         None => ""
     };
 
-    execute_command(Command::new("cargo").arg("update"));
+    if !matched_args.is_present("skip-update") {
+        execute_command(Command::new("cargo").arg("update"));
+    }
 
     let cargo_toml = get_toml("Cargo.toml");
     let top_pkg_name = parse_package_name(&cargo_toml);
@@ -35,8 +38,6 @@ fn main() {
     for dep in deps {
         build_package(&dep, is_release, &target);
     }
-
-    println!("done");
 }
 
 fn get_toml(file_path: &str) -> Toml {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,15 @@
-extern crate toml;
 extern crate clap;
+extern crate toml;
+
+use clap::{App, Arg};
+use toml::Value as Toml;
 
 use std::env;
-use std::io::prelude::*;
 use std::fs::File;
-use toml::Value as Toml;
+use std::io::prelude::*;
 use std::process::Command;
-use clap::{App, Arg};
 
 fn main() {
-
     let matched_args = App::new("cargo build-deps")
         .arg(Arg::with_name("build-deps"))
         .arg(Arg::with_name("release").long("release"))
@@ -20,7 +20,7 @@ fn main() {
     let is_release = matched_args.is_present("release");
     let target = match matched_args.value_of("target") {
         Some(value) => value,
-        None => ""
+        None => "",
     };
 
     if !matched_args.is_present("skip-update") {
@@ -28,79 +28,54 @@ fn main() {
     }
 
     let cargo_toml = get_toml("Cargo.toml");
-    let top_pkg_name = parse_package_name(&cargo_toml);
+    let dependencies = parse_dependencies(&cargo_toml);
 
-    let cargo_lock = get_toml("Cargo.lock");
-    let deps = parse_deps(&cargo_lock, top_pkg_name);
+    println!("Start building packages");
 
-    println!("building packages: {:?}", deps);
-
-    for dep in deps {
-        build_package(&dep, is_release, &target);
+    for dependency in dependencies {
+        build_package(&dependency, is_release, &target);
     }
+
+    println!("Finished");
 }
 
 fn get_toml(file_path: &str) -> Toml {
-    let mut toml_file = File::open(file_path).unwrap();
+    let mut toml_file = File::open(file_path).expect(&format!("{} is not available", file_path));
     let mut toml_string = String::new();
-    toml_file.read_to_string(&mut toml_string).unwrap();
-    toml_string.parse().expect("failed to parse toml")
+    toml_file
+        .read_to_string(&mut toml_string)
+        .expect("Can't read file");
+    toml_string.parse().expect("Failed to parse toml")
 }
 
-fn parse_package_name(toml: &Toml) -> &str {
-    match toml {
-        &Toml::Table(ref table) => {
-            match table.get("package") {
-                Some(&Toml::Table(ref table)) => {
-                    match table.get("name") {
-                        Some(&Toml::String(ref name)) => name,
-                        _ => panic!("failed to parse name"),
-                    }
-                }
-                _ => panic!("failed to parse package"),
-            }
-        }
-        _ => panic!("failed to parse Cargo.toml: incorrect format"),
+fn parse_dependencies<'a>(toml: &'a Toml) -> Vec<String> {
+    match toml.get("dependencies") {
+        Some(&Toml::Table(ref pkgs)) => pkgs
+            .iter()
+            .map(|(name, value)| format_package(name, value))
+            .collect(),
+        _ => panic!("Failed to find dependencies in Cargo.toml"),
     }
 }
 
-fn parse_deps<'a>(toml: &'a Toml, top_pkg_name: &str) -> Vec<String> {
-    match toml.get("package") {
-        Some(&Toml::Array(ref pkgs)) => {
-            let top_pkg = pkgs.iter()
-                .find(|pkg| pkg.get("name").unwrap().as_str().unwrap() == top_pkg_name);
-            match top_pkg {
-                Some(&Toml::Table(ref pkg)) => {
-                    match pkg.get("dependencies") {
-                        Some(&Toml::Array(ref deps_toml_array)) => {
-                            deps_toml_array.iter()
-                                .map(|value| {
-                                    let mut value_parts = value.as_str().unwrap().split(" ");
-                                    format!("{}:{}",
-                                            value_parts.next()
-                                                .expect("failed to parse name from depencency \
-                                                         string"),
-                                            value_parts.next()
-                                                .expect("failed to parse version from depencency \
-                                                         string"))
-                                })
-                                .collect()
-                        }
-                        _ => panic!("error parsing dependencies table"),
-                    }
-                }
-                _ => panic!("failed to find top package"),
-            }
+fn format_package(name: &String, value: &Toml) -> String {
+    match value {
+        Toml::String(string) => format!("{}:{}", name, string.replace("\"", "")),
+        Toml::Table(table) => {
+            let value = match table.get("version") {
+                Some(v) => v.to_string().replace("\"", ""),
+                None => "".to_string(),
+            };
+            format!("{}:{}", name, value)
         }
-        _ => panic!("failed to find packages in Cargo.lock"),
+        _ => panic!("Failed to format package-id"),
     }
 }
 
 fn build_package(pkg_name: &str, is_release: bool, target: &str) {
-    println!("building package: {:?}", pkg_name);
+    println!("Building package: {:?}", pkg_name);
 
     let mut command = Command::new("cargo");
-
     let command_with_args = command.arg("build").arg("-p").arg(pkg_name);
 
     let command_with_args = if is_release {
@@ -119,9 +94,12 @@ fn build_package(pkg_name: &str, is_release: bool, target: &str) {
 }
 
 fn execute_command(command: &mut Command) {
-    let mut child = command.envs(env::vars()).spawn().expect("failed to execute process");
+    let mut child = command
+        .envs(env::vars())
+        .spawn()
+        .expect("Failed to execute process");
 
-    let exit_status = child.wait().expect("failed to run command");
+    let exit_status = child.wait().expect("Failed to run command");
 
     if !exit_status.success() {
         match exit_status.code() {


### PR DESCRIPTION
- Cargo.toml can contain dependencies with non-semver versions. This is an issue because cargo build <pkg>:<version> requires a semver version. **Fix:** added cargo metadata parsing to get a semver version
- **Added:** `--skip-update` flag, as you don't always want to run `cargo update`
- **Fixed:** Can now parse complex `Cargo.toml` entries, like `dep: { version: "0.0.1", ... }`
- **Changed:** The logging is now prefixed by 4 spaces to match `cargo`'s log output
